### PR TITLE
caps_word consume sticky key

### DIFF
--- a/config/boards/shields/piano/piano.keymap
+++ b/config/boards/shields/piano/piano.keymap
@@ -126,6 +126,13 @@
             #binding-cells = <0>;
             bindings = <&macro_tap &kp ESC &kp COLON &kp X &kp RET>;
         };
+
+        rcw: realeasable_caps_word {
+            compatible = "zmk,behavior-macro";
+            label = "RELEASEABLE_CAPS_WORD";
+            #binding-cells = <0>;
+            bindings = <&macro_tap &kp F17 &caps_word>;
+        };
     };
 
     behaviors {
@@ -165,7 +172,7 @@
         bindings = <
                 &mt LCTRL DOT   &mt LALT  Y     &mt LCMD  F     &mt RCMD  G     &mt RALT  L     &mt RCTRL V
 &kp Q           &kp X           &kp J           &kp K           &kp B           &kp M           &kp W           &kp RET
-                                &trans          &kp UNDER       &caps_word      &kp Z
+                                &trans          &kp UNDER       &rcw            &kp Z
         >;
         };
 


### PR DESCRIPTION
while using the `&sk` to go to the 2nd layer and press the `&caps_word`,
the sticky key is not consumed, and the shield remains in layer 2 instead of 1.

added a macro to workaround this.
ref: https://github.com/zmkfirmware/zmk/issues/834